### PR TITLE
Fix `size` parameter when loading gensim Word2Vec

### DIFF
--- a/nodevectors/node2vec.py
+++ b/nodevectors/node2vec.py
@@ -129,7 +129,7 @@ class Node2Vec(BaseNodeEmbedder):
         # Train gensim word2vec model on random walks
         self.model = gensim.models.Word2Vec(
             sentences=self.walks,
-            size=self.n_components,
+            vector_size=self.n_components,
             **self.w2vparams)
         if not self.keep_walks:
             del self.walks


### PR DESCRIPTION
The parameter is now called `vector_size`. See: https://stackoverflow.com/a/67080756