### PR TITLE
NetworkX versioning and naming in Word2Vec

### DIFF
--- a/nodevectors/node2vec.py
+++ b/nodevectors/node2vec.py
@@ -129,7 +129,7 @@ class Node2Vec(BaseNodeEmbedder):
         # Train gensim word2vec model on random walks
         self.model = gensim.models.Word2Vec(
             sentences=self.walks,
-            size=self.n_components,
+            vector_size=self.n_components,
             **self.w2vparams)
         if not self.keep_walks:
             del self.walks

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
     'csrgraph',
     'gensim',
-    'networkx',
+    'networkx <= 3.0',
     'numba',
     'numpy',
     'pandas >= 1.0',


### PR DESCRIPTION
NetworkX > 3.0 changed how they name the adjacency matrix, and Word2Vec changed naming of the size of the word/node vector. These changes fix the relevant code/version requirements in setup.py. See the two separate commits for the small changes to the code.