### PR TITLE
Improve compatibility with gensim and csrgraph

### DIFF
--- a/nodevectors/ggvec.py
+++ b/nodevectors/ggvec.py
@@ -1,5 +1,6 @@
 import csrgraph as cg
 from nodevectors.embedders import BaseNodeEmbedder
+from gensim.models import KeyedVectors
 
 class GGVec(BaseNodeEmbedder):
     def __init__(self, 
@@ -118,3 +119,24 @@ class GGVec(BaseNodeEmbedder):
             verbose=self.verbose)
         self.model = dict(zip(G.nodes(), vectors))
         return vectors
+  
+    @staticmethod
+    def save_vectors(instance, save_path):
+        """
+        Save node vectors in Word2Vec format.
+
+        Parameters
+        ----------
+        instance : GGVec
+            An instance of the GGVec model containing the node vectors
+        save_path : str
+            Path where the Word2Vec file will be saved
+        """
+        node_ids = list(map(str, instance.model.keys()))
+        vectors = list(instance.model.values())
+
+        kv = KeyedVectors(vector_size=len(vectors[0]))
+        kv.add_vectors(node_ids, vectors)
+
+        # Save in Word2Vec format
+        kv.save_word2vec_format(save_path, binary=True)

--- a/nodevectors/prone.py
+++ b/nodevectors/prone.py
@@ -6,6 +6,7 @@ from sklearn.utils.extmath import randomized_svd
 
 from nodevectors.embedders import BaseNodeEmbedder
 import csrgraph as cg
+from gensim.models import KeyedVectors
 
 class ProNE(BaseNodeEmbedder):
     def __init__(self, n_components=32, step=10, mu=0.2, theta=0.5, 
@@ -173,3 +174,24 @@ class ProNE(BaseNodeEmbedder):
         mm = A.dot(a - conv)
         emb = ProNE.svd_dense(mm, n_components)
         return emb
+    
+    @staticmethod
+    def save_vectors(instance, save_path):
+        """
+        Save node vectors in Word2Vec format.
+
+        Parameters
+        ----------
+        instance : ProNE
+            An instance of the ProNE model containing the node vectors
+        save_path : str
+            Path where the Word2Vec file will be saved
+        """
+        node_ids = list(map(str, instance.model.keys()))
+        vectors = list(instance.model.values())
+        
+        kv = KeyedVectors(vector_size=len(vectors[0]))
+        kv.add_vectors(node_ids, vectors)
+
+        # Save in Word2Vec format
+        kv.save_word2vec_format(save_path, binary=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 csrgraph
 gensim
-networkx
+networkx==2.5.1
 numba
 numpy
 pandas

--- a/tests/test_node2vec.py
+++ b/tests/test_node2vec.py
@@ -27,7 +27,7 @@ class TestGraphEmbedding(unittest.TestCase):
             n_components=wordsize,
             keep_walks=True,
             verbose=False,
-            w2vparams={"window":3, "negative":3, "iter":3,
+            w2vparams={"window":3, "negative":3, "epochs":3,
                        "batch_words":32, "workers": 2})
         g2v2 = nodevectors.Node2Vec(
             walklen=5, 
@@ -36,7 +36,7 @@ class TestGraphEmbedding(unittest.TestCase):
             n_components=wordsize,
             keep_walks=False,
             verbose=False,
-            w2vparams={"window":3, "negative":3, "iter":3,
+            w2vparams={"window":3, "negative":3, "epochs":3,
                        "batch_words":32, "workers": 2})
         g2v.fit(tt)
         g2v2.fit(tt)
@@ -202,7 +202,7 @@ class TestGraphEmbedding(unittest.TestCase):
             n_components=ndim,
             keep_walks=True,
             verbose=False,
-            w2vparams={"window":3, "negative":3, "iter":3,
+            w2vparams={"window":3, "negative":3, "epochs":3,
                        "batch_words":32, "workers": 2})
         skle.fit(tt)
         res_v = skle.predict(9)
@@ -229,6 +229,6 @@ class TestGraphEmbedding(unittest.TestCase):
             n_components=ndim,
             keep_walks=True,
             verbose=False,
-            w2vparams={"window":3, "negative":3, "iter":3,
+            w2vparams={"window":3, "negative":3, "epochs":3,
                        "batch_words":32, "workers": 2})
         skle.fit_transform(tt)


### PR DESCRIPTION
1. **Update 'iter' to 'epochs' for Gensim compatibility**:
   - Replaced the `iter` parameter with `epochs` to ensure compatibility with the latest [Gensim versions](https://github.com/piskvorky/gensim/blob/develop/gensim/models/word2vec.py#L325-L326).

2. **Update dependencies and pin networkx to v2.5.1**:
   - Downgraded `networkx` to version 2.5.1 to ensure compatibility with `csrgraph`.

3. **Add method to save node vectors in Word2Vec format**:
   - Added a new `save_vectors` static method to the ProNE and GGVec classes.
   - This method saves node embeddings in the binary Word2Vec format.

4. **Refactor `fit_transform` method**:
   - Replaced the use of pandas with a direct approach using list comprehension and `G.names` to simplify the code and improve performance.